### PR TITLE
Bump codependent dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ MarkupSafe==2.1.1
 matplotlib==3.6.0
 matplotlib-inline==0.1.6
 mccabe==0.7.0
-mistune==0.8.4
+mistune==2.0.4
 mypy==0.982
 mypy-extensions==0.4.3
 nbclient==0.6.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,7 @@ mistune==2.0.4
 mypy==0.982
 mypy-extensions==0.4.3
 nbclient==0.6.8
-nbconvert==6.5.3
+nbconvert==7.1.0
 nbformat==5.6.1
 nbsphinx==0.8.9
 nest-asyncio==1.5.6


### PR DESCRIPTION
Bump:
- `nbconvert` from 6.5.3 to 7.1.0
- `mistune` from 0.8.4 to 2.0.4