### PR TITLE
Use transmitted flux in flux dependant dark current

### DIFF
--- a/src/adcorr/corrections/dark_current.py
+++ b/src/adcorr/corrections/dark_current.py
@@ -6,6 +6,7 @@ from ..utils.typing import FrameHeight, Frames, FrameWidth, NumFrames, VectorOrS
 def correct_dark_current(
     frames: Frames[NumFrames, FrameWidth, FrameHeight, dtype[number]],
     count_times: ndarray[VectorOrSingle[NumFrames], dtype[floating]],
+    transmitted_flux: ndarray[VectorOrSingle[NumFrames], dtype[floating]],
     base_dark_current: float,
     temporal_dark_current: float,
     flux_dependant_dark_current: float,
@@ -20,6 +21,8 @@ def correct_dark_current(
     Args:
         frames: A stack of frames to be corrected.
         count_times: The period over which photons are counted for each frame.
+        transmitted_flux: The flux intensity observed downstream of the sample
+            for each frame.
         base_dark_current: The dark current flux, irrespective of time.
         temporal_dark_current: The dark current flux, as a factor of time.
         flux_dependant_dark_current: The dark current flux, as a factor of incident
@@ -30,6 +33,8 @@ def correct_dark_current(
     """
     if (count_times <= 0).any():
         raise ValueError("Count times must be positive.")
+    if (transmitted_flux <= 0).any():
+        raise ValueError("Transmitted flux must be positive.")
     if base_dark_current < 0:
         raise ValueError("Base Dark Current must be non-negative.")
     if temporal_dark_current < 0:
@@ -38,5 +43,7 @@ def correct_dark_current(
         raise ValueError("Flux Dependant Dark Current must be non-negative.")
 
     temporal = temporal_dark_current * expand_dims(atleast_1d(count_times), (1, 2))
-    flux_dependant = flux_dependant_dark_current * frames
+    flux_dependant = flux_dependant_dark_current * expand_dims(
+        atleast_1d(transmitted_flux), (1, 2)
+    )
     return frames - base_dark_current - temporal - flux_dependant

--- a/tests/corrections/test_dark_current.py
+++ b/tests/corrections/test_dark_current.py
@@ -9,12 +9,17 @@ def test_correct_dark_current_typical_2x2():
     assert isclose(
         array(
             [
-                [0.79, 1.69],
-                [2.59, 3.49],
+                [0.88, 1.88],
+                [2.88, 3.88],
             ]
         ),
         correct_dark_current(
-            array([[1.0, 2.0], [3.0, 4.0]]), array([0.1]), 0.1, 0.1, 0.1
+            array([[1.0, 2.0], [3.0, 4.0]]),
+            array([0.1]),
+            array([10.0]),
+            0.1,
+            0.1,
+            0.001,
         ),
     ).all()
 
@@ -23,17 +28,18 @@ def test_correct_dark_current_typical_3x3():
     assert isclose(
         array(
             [
-                [0.79, 1.69, 2.59],
-                [3.49, 4.39, 5.29],
-                [6.19, 7.09, 7.99],
+                [0.88, 1.88, 2.88],
+                [3.88, 4.88, 5.88],
+                [6.88, 7.88, 8.88],
             ]
         ),
         correct_dark_current(
             array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]]),
             array([0.1]),
+            array([100.0]),
             0.1,
             0.1,
-            0.1,
+            0.0001,
         ),
     ).all()
 
@@ -43,21 +49,22 @@ def test_correct_dark_current_typical_2x2x2():
         array(
             [
                 [
-                    [0.79, 1.69],
-                    [2.59, 3.49],
+                    [0.88, 1.88],
+                    [2.88, 3.88],
                 ],
                 [
-                    [4.39, 5.29],
-                    [6.19, 7.09],
+                    [4.79, 5.79],
+                    [6.79, 7.79],
                 ],
             ]
         ),
         correct_dark_current(
             array([[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]]),
             array([0.1, 0.1]),
+            array([5.0, 50.0]),
             0.1,
             0.1,
-            0.1,
+            0.002,
         ),
     ).all()
 
@@ -66,8 +73,8 @@ def test_correct_dark_current_masked_2x2():
     assert isclose(
         array(
             [
-                [Inf, 1.69],
-                [2.59, Inf],
+                [Inf, 1.88],
+                [2.88, Inf],
             ]
         ),
         correct_dark_current(
@@ -76,9 +83,10 @@ def test_correct_dark_current_masked_2x2():
                 array([[1.0, 2.0], [3.0, 4.0]]),
             ),
             array([0.1]),
+            array([10.0]),
             0.1,
             0.1,
-            0.1,
+            0.001,
         ).filled(Inf),
     ).all()
 
@@ -88,21 +96,22 @@ def test_correct_dark_current_count_times_singular():
         array(
             [
                 [
-                    [0.79, 1.69],
-                    [2.59, 3.49],
+                    [0.88, 1.88],
+                    [2.88, 3.88],
                 ],
                 [
-                    [4.39, 5.29],
-                    [6.19, 7.09],
+                    [4.88, 5.88],
+                    [6.88, 7.88],
                 ],
             ]
         ),
         correct_dark_current(
             array([[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]]),
             array([0.1]),
+            array([10.0]),
             0.1,
             0.1,
-            0.1,
+            0.001,
         ),
     ).all()
 
@@ -112,21 +121,22 @@ def test_correct_dark_current_count_times_vector():
         array(
             [
                 [
-                    [0.79, 1.69],
-                    [2.59, 3.49],
+                    [0.88, 1.88],
+                    [2.88, 3.88],
                 ],
                 [
-                    [4.38, 5.28],
-                    [6.18, 7.08],
+                    [4.87, 5.87],
+                    [6.87, 7.87],
                 ],
             ]
         ),
         correct_dark_current(
             array([[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]]),
             array([0.1, 0.2]),
+            array([10.0]),
             0.1,
             0.1,
-            0.1,
+            0.001,
         ),
     ).all()
 
@@ -136,9 +146,10 @@ def test_correct_dark_current_count_times_zero():
         correct_dark_current(
             array([[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]]),
             array([0.0]),
+            array([10.0]),
             0.1,
             0.1,
-            0.1,
+            0.001,
         )
 
 
@@ -147,9 +158,84 @@ def test_correct_dark_current_count_times_negative():
         correct_dark_current(
             array([[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]]),
             array([0.1, -0.1]),
+            array([10.0]),
             0.1,
             0.1,
+            0.001,
+        )
+
+
+def test_correct_dark_current_transmitted_flux_singular():
+    assert isclose(
+        array(
+            [
+                [
+                    [0.88, 1.88],
+                    [2.88, 3.88],
+                ],
+                [
+                    [4.88, 5.88],
+                    [6.88, 7.88],
+                ],
+            ]
+        ),
+        correct_dark_current(
+            array([[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]]),
+            array([0.1]),
+            array([10.0]),
             0.1,
+            0.1,
+            0.001,
+        ),
+    ).all()
+
+
+def test_correct_dark_current_transmitted_flux_vector():
+    assert isclose(
+        array(
+            [
+                [
+                    [0.88, 1.88],
+                    [2.88, 3.88],
+                ],
+                [
+                    [4.87, 5.87],
+                    [6.87, 7.87],
+                ],
+            ]
+        ),
+        correct_dark_current(
+            array([[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]]),
+            array([0.1]),
+            array([10.0, 20.0]),
+            0.1,
+            0.1,
+            0.001,
+        ),
+    ).all()
+
+
+def test_correct_dark_current_transmitted_flux_zero():
+    with raises(ValueError):
+        correct_dark_current(
+            array([[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]]),
+            array([0.1]),
+            array([0.0]),
+            0.1,
+            0.1,
+            0.001,
+        )
+
+
+def test_correct_dark_current_transmitted_flux_negative():
+    with raises(ValueError):
+        correct_dark_current(
+            array([[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]]),
+            array([0.1]),
+            array([10.0, -10.0]),
+            0.1,
+            0.1,
+            0.001,
         )
 
 
@@ -157,12 +243,17 @@ def test_correct_dark_current_base_dark_current_zero():
     assert isclose(
         array(
             [
-                [0.89, 1.79],
-                [2.69, 3.59],
+                [0.98, 1.98],
+                [2.98, 3.98],
             ]
         ),
         correct_dark_current(
-            array([[1.0, 2.0], [3.0, 4.0]]), array([0.1]), 0.0, 0.1, 0.1
+            array([[1.0, 2.0], [3.0, 4.0]]),
+            array([0.1]),
+            array([10.0]),
+            0.0,
+            0.1,
+            0.001,
         ),
     ).all()
 
@@ -170,7 +261,12 @@ def test_correct_dark_current_base_dark_current_zero():
 def test_correct_dark_current_base_dark_current_negative():
     with raises(ValueError):
         correct_dark_current(
-            array([[1.0, 2.0], [3.0, 4.0]]), array([0.1]), -0.1, 0.1, 0.1
+            array([[1.0, 2.0], [3.0, 4.0]]),
+            array([0.1]),
+            array([10.0]),
+            -0.1,
+            0.1,
+            0.001,
         )
 
 
@@ -178,12 +274,17 @@ def test_correct_dark_current_temporal_dark_current_zero():
     assert isclose(
         array(
             [
-                [0.80, 1.70],
-                [2.60, 3.50],
+                [0.89, 1.89],
+                [2.89, 3.89],
             ]
         ),
         correct_dark_current(
-            array([[1.0, 2.0], [3.0, 4.0]]), array([0.1]), 0.1, 0.0, 0.1
+            array([[1.0, 2.0], [3.0, 4.0]]),
+            array([0.1]),
+            array([10.0]),
+            0.1,
+            0.0,
+            0.001,
         ),
     ).all()
 
@@ -191,7 +292,12 @@ def test_correct_dark_current_temporal_dark_current_zero():
 def test_correct_dark_current_temporal_dark_current_negative():
     with raises(ValueError):
         correct_dark_current(
-            array([[1.0, 2.0], [3.0, 4.0]]), array([0.1]), 0.1, -0.1, 0.1
+            array([[1.0, 2.0], [3.0, 4.0]]),
+            array([0.1]),
+            array([10.0]),
+            0.1,
+            -0.1,
+            0.001,
         )
 
 
@@ -204,7 +310,7 @@ def test_correct_dark_current_flux_dependant_dark_current_zero():
             ]
         ),
         correct_dark_current(
-            array([[1.0, 2.0], [3.0, 4.0]]), array([0.1]), 0.1, 0.1, 0.0
+            array([[1.0, 2.0], [3.0, 4.0]]), array([0.1]), array([10.0]), 0.1, 0.1, 0.0
         ),
     ).all()
 
@@ -212,5 +318,10 @@ def test_correct_dark_current_flux_dependant_dark_current_zero():
 def test_correct_dark_current_flux_dependant_dark_current_negative():
     with raises(ValueError):
         correct_dark_current(
-            array([[1.0, 2.0], [3.0, 4.0]]), array([0.1]), 0.1, 0.1, -0.1
+            array([[1.0, 2.0], [3.0, 4.0]]),
+            array([0.1]),
+            array([10.0]),
+            0.1,
+            0.1,
+            -0.001,
         )


### PR DESCRIPTION
Use transmitted flux to compute flux dependant dark current as in [Everything SAXS](https://doi.org/10.1088/0953-8984/25/38/383201)