### PR TITLE
Use seconds past epoch in pretend version

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -143,7 +143,7 @@ jobs:
 
       - name: Set fake version if untagged
         if: github.event_name != 'push' || !startsWith(github.ref, 'refs/tags')
-        run: echo "SETUPTOOLS_SCM_PRETEND_VERSION=$(git describe --tags | cut -d '-' -f 1,2 --output-delimiter '.dev')" >> $GITHUB_ENV
+        run: echo "SETUPTOOLS_SCM_PRETEND_VERSION=$(git describe --tags --abbrev=0).$(date +%s)" >> $GITHUB_ENV
 
       - name: Build Sdist
         # Set SOURCE_DATE_EPOCH from git commit for reproducible build


### PR DESCRIPTION
Use seconds past epoch in Code CI pretend version to prevent clashes when merging to `main`